### PR TITLE
avoid segfaults with vectors

### DIFF
--- a/fix_includes.cpp
+++ b/fix_includes.cpp
@@ -46,17 +46,19 @@ private:
                 file.emplace(begin);
             }
         }
-        if (end != file.end())
-            file.emplace(end);
     }
 
     static void FixIncludesInRange(SourceFile& file, SourceFile::iterator begin, SourceFile::iterator end) {
         RemoveEmptyLinesInRange(file, begin, end);
-        std::sort(begin, end, [](const auto& a, const auto& b) {
+        std::list<Line> to_sort;
+        to_sort.splice(to_sort.end(), file, begin, end);
+        to_sort.sort([](const auto& a, const auto& b) {
             if (a.Type != b.Type)
                 return static_cast<int>(a.Type) < static_cast<int>(b.Type);
             return dynamic_cast<const std::string&>(a) < dynamic_cast<const std::string&>(b);
         });
+        begin = to_sort.begin();
+        file.splice(end, to_sort, to_sort.begin(), to_sort.end());
         file.erase(std::unique(begin, end), end);
         AddEmptyLinesToRange(file, begin, end);
     }

--- a/source_file.hpp
+++ b/source_file.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <list>
 #include <tuple>
 
 class Line : public std::string {
@@ -27,7 +28,7 @@ public:
     }
 };
 
-class SourceFile : public std::vector<Line> {
+class SourceFile : public std::list<Line> {
 public:
     void ReadFromFile(std::string_view filename);
     void WriteToFile(std::string_view filename);


### PR DESCRIPTION
There were some problems with invalidated iterators with tests like below in function `RemoveEmptyLinesInRange`. 
![2017-08-28-162306_216x160_scrot](https://user-images.githubusercontent.com/15173761/29777686-8a5c1c36-8c15-11e7-833d-331f04959a8c.png)

So list is better variant for such purposes.

By the way, `\n` is always added after all includes so it is not good to add it all the time, so change to 49-50 lines are also added.
